### PR TITLE
Refactor: move all OpenCV code in same package

### DIFF
--- a/internal/detect/display.go
+++ b/internal/detect/display.go
@@ -1,4 +1,4 @@
-package main
+package detect
 
 import (
 	"image"
@@ -7,12 +7,7 @@ import (
 	"gocv.io/x/gocv"
 )
 
-const (
-	miniCodeWidth  = 200
-	miniCodeHeight = 200
-)
-
-func setMiniCodeInCorner(img *gocv.Mat, points []image.Point, width, height int) gocv.Mat {
+func SetMiniCodeInCorner(img *gocv.Mat, points []image.Point, width, height int) gocv.Mat {
 	originVector := gocv.NewPointVectorFromPoints(points)
 	defer originVector.Close()
 	destinationVector := gocv.NewPointVectorFromPoints([]image.Point{
@@ -30,7 +25,7 @@ func setMiniCodeInCorner(img *gocv.Mat, points []image.Point, width, height int)
 	return rectangle
 }
 
-func outlineQRCode(img *gocv.Mat, points []image.Point, color color.RGBA, width int) {
+func OutlineQRCode(img *gocv.Mat, points []image.Point, color color.RGBA, width int) {
 	gocv.Line(img, points[0], points[1], color, width)
 	gocv.Line(img, points[1], points[2], color, width)
 	gocv.Line(img, points[2], points[3], color, width)

--- a/main.go
+++ b/main.go
@@ -72,6 +72,11 @@ func main() {
 	}
 }
 
+const (
+	miniCodeWidth  = 200
+	miniCodeHeight = 200
+)
+
 // scanCode extracts the QR-code from the given image, then decodes it.
 // If successful, returns a new image with miniature QR-code in the top-left corner and the message.
 // Otherwise, returns the original image.
@@ -104,7 +109,7 @@ func scanCode(img, imgWithMiniCode *gocv.Mat, points *gocv.Mat, width, height in
 	// fmt.Println("Points form a square, proceed")
 
 	img.CopyTo(imgWithMiniCode)
-	miniCode := setMiniCodeInCorner(imgWithMiniCode, imagePoints, miniCodeWidth, miniCodeHeight)
+	miniCode := detect.SetMiniCodeInCorner(imgWithMiniCode, imagePoints, miniCodeWidth, miniCodeHeight)
 	detect.EnhanceImage(&miniCode)
 
 	dots, ok := detect.GetDots(miniCode)
@@ -128,7 +133,7 @@ func scanCode(img, imgWithMiniCode *gocv.Mat, points *gocv.Mat, width, height in
 	}
 
 	printQRCode(dots)
-	outlineQRCode(imgWithMiniCode, imagePoints, color.RGBA{255, 0, 0, 255}, 5)
+	detect.OutlineQRCode(imgWithMiniCode, imagePoints, color.RGBA{255, 0, 0, 255}, 5)
 
 	return *imgWithMiniCode, true, message
 }


### PR DESCRIPTION
Mini-code generation and display + QR-code outline moved to internal/detect package, along with all other OpenCV-related code.

@sebastienchedor Je suis pas 100% convaincu de ça… je pense que c'est un peu mieux, mais j'aimerais ton avis aussi